### PR TITLE
Add benchmarks from byteorder 1.2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
 
   brotli_1_1_3:
     <<: *bench_crate
+  byteorder_1_2_6:
+    <<: *bench_crate
   inflate_0_3_4:
     <<: *bench_crate
   rayon_1_0_0:
@@ -132,6 +134,9 @@ workflows:
           requires:
             - fmt
       - brotli_1_1_3:
+          requires:
+            - fmt
+      - byteorder_1_2_6:
           requires:
             - fmt
       - inflate_0_3_4:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,15 +233,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.2"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder_1_2_6"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lolbench 0.0.1",
+ "lolbench_support 0.1.0",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bytes"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -450,7 +460,7 @@ dependencies = [
 name = "criterion-plot"
 version = "0.2.1"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +576,7 @@ name = "diesel"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1105,7 +1115,7 @@ name = "lolbench"
 version = "0.0.1"
 dependencies = [
  "askama 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.1",
@@ -1607,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1951,7 +1961,7 @@ name = "snap"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2107,7 +2117,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2127,7 +2137,7 @@ name = "term"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2524,7 +2534,7 @@ dependencies = [
 "checksum brotli-decompressor 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "358f28e94689d14c621de44c6813555abeadf0c95c3e1f3f13943deb9eb98dc8"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
-"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
@@ -2652,7 +2662,7 @@ dependencies = [
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "12397506224b2f93e6664ffc4f664b29be8208e5157d3d90b44f09b5fae470ea"
+"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum rawslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b23b9f57ea250c6db4b21e2897b43ff08209217ca8260469fae6c0f9ad7e25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ askama = "0.7"
 [workspace]
 members = [
     "./benches/brotli_1_1_3",
+    "./benches/byteorder_1_2_6",
     "./benches/crossbeam_epoch_0_4_0",
     "./benches/diesel_1_1_1",
     "./benches/doom_9e197d7",

--- a/benches/byteorder_1_2_6/Cargo.toml
+++ b/benches/byteorder_1_2_6/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "byteorder_1_2_6"
+version = "0.1.0"
+authors = ['Thom wiggers <thom@thomwiggers.nl>']
+
+[dependencies]
+byteorder = "=1.2.6"
+rand = "=0.5.5"
+lolbench_support = { path = "../../support" }
+
+[dev-dependencies]
+lolbench = { path = "../../" }
+
+[features]
+default = ["i128"]
+i128 = ["byteorder/i128"]

--- a/benches/byteorder_1_2_6/src/bin/f32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f32 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/f64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/f64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: f64 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i128-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i128-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i128 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i16-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i16-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i16 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i32 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/i64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/i64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: i64 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_1 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_1 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_1 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_2 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_2 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_2 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_3 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_3 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_3 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_4 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_4 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_4 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_5 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_5 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_5 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_6 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_6 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_6 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_7 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_7 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_7 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_8 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_8 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int_8 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_1 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_1 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_1 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-10-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-10-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_10 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-10-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-10-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_10 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-10-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-10-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_10 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-11-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-11-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_11 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-11-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-11-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_11 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-11-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-11-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_11 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-12-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-12-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_12 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-12-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-12-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_12 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-12-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-12-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_12 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-13-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-13-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_13 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-13-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-13-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_13 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-13-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-13-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_13 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-14-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-14-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_14 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-14-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-14-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_14 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-14-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-14-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_14 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-15-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-15-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_15 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-15-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-15-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_15 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-15-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-15-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_15 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_16 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_16 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_16 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_2 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_2 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_2 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_3 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_3 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_3 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_4 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_4 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_4 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_5 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_5 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_5 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_6 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_6 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_6 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_7 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_7 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_7 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_8 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_8 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_8 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-9-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-9-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_9 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-9-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-9-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_9 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/int128-9-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/int128-9-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: int128_9 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/slice-u64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/slice-u64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: slice_u64 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/slice-u64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/slice-u64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: slice_u64 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/slice-u64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/slice-u64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: slice_u64 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/slice-u64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/slice-u64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: slice_u64 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u128-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u128-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u128 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u16-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u16-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u16 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u32 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: write_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: write_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/u64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/u64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: u64 :: write_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_1 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_1 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_1 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_2 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_2 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_2 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_3 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_3 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_3 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_4 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_4 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_4 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_5 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_5 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_5 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_6 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_6 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_6 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_7 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_7 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_7 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_8 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_8 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint_8 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_1 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_1 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_1 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-10-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-10-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_10 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-10-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-10-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_10 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-10-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-10-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_10 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-11-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-11-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_11 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-11-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-11-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_11 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-11-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-11-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_11 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-12-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-12-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_12 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-12-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-12-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_12 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-12-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-12-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_12 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-13-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-13-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_13 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-13-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-13-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_13 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-13-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-13-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_13 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-14-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-14-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_14 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-14-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-14-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_14 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-14-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-14-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_14 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-15-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-15-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_15 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-15-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-15-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_15 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-15-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-15-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_15 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_16 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_16 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_16 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_2 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_2 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_2 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_3 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_3 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_3 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_4 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_4 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_4 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_5 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_5 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_5 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_6 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_6 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_6 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_7 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_7 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_7 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_8 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_8 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_8 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-9-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-9-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_9 :: read_big_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-9-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-9-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_9 :: read_little_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/bin/uint128-9-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/src/bin/uint128-9-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate byteorder_1_2_6 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; byteorder_1_2_6 :: uint128_9 :: read_native_endian ( & mut crit ) ; }

--- a/benches/byteorder_1_2_6/src/lib.rs
+++ b/benches/byteorder_1_2_6/src/lib.rs
@@ -1,0 +1,357 @@
+//! Benchmarks from byteorder 1.2.6
+//!
+//! The code in this module was adapted from the Byteorder crate by
+//! BurntSushi and contributors.
+//!
+//! It's available under the MIT and UNLICENSE licenses.
+//!
+//! See https://github.com/BurntSushi/byteorder
+#[macro_use]
+extern crate lolbench_support;
+
+extern crate byteorder;
+extern crate rand;
+
+macro_rules! bench_num {
+    ($name:ident, $read:ident, $bytes:expr, $data:expr) => (
+        pub mod $name {
+            use byteorder::{ByteOrder, BigEndian, NativeEndian, LittleEndian};
+
+            const NITER: usize = 100_000;
+
+            wrap_libtest! {
+                $name,
+                fn read_big_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(BigEndian::$read(&buf, $bytes));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $name,
+                fn read_little_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(LittleEndian::$read(&buf, $bytes));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $name,
+                fn read_native_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(NativeEndian::$read(&buf, $bytes));
+                        }
+                    });
+                }
+            }
+        }
+    );
+    ($ty:ident, $max:ident,
+     $read:ident, $write:ident, $size:expr, $data:expr) => (
+        pub mod $ty {
+            use std::$ty;
+            use byteorder::{ByteOrder, BigEndian, NativeEndian, LittleEndian};
+
+            const NITER: usize = 100_000;
+
+            wrap_libtest! {
+                $ty,
+                fn read_big_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(BigEndian::$read(&buf));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $ty,
+                fn read_little_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(LittleEndian::$read(&buf));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $ty,
+                fn read_native_endian(b: &mut Bencher) {
+                    let buf = $data;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(NativeEndian::$read(&buf));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $ty,
+                fn write_big_endian(b: &mut Bencher) {
+                    let mut buf = $data;
+                    let n = $ty::$max;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(BigEndian::$write(&mut buf, n));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $ty,
+                fn write_little_endian(b: &mut Bencher) {
+                    let mut buf = $data;
+                    let n = $ty::$max;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(LittleEndian::$write(&mut buf, n));
+                        }
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $ty,
+                fn write_native_endian(b: &mut Bencher) {
+                    let mut buf = $data;
+                    let n = $ty::$max;
+                    b.iter(|| {
+                        for _ in 0..NITER {
+                            black_box(NativeEndian::$write(&mut buf, n));
+                        }
+                    });
+                }
+            }
+        }
+    );
+}
+
+bench_num!(u16, MAX, read_u16, write_u16, 2, [1, 2]);
+bench_num!(i16, MAX, read_i16, write_i16, 2, [1, 2]);
+bench_num!(u32, MAX, read_u32, write_u32, 4, [1, 2, 3, 4]);
+bench_num!(i32, MAX, read_i32, write_i32, 4, [1, 2, 3, 4]);
+bench_num!(u64, MAX, read_u64, write_u64, 8, [1, 2, 3, 4, 5, 6, 7, 8]);
+bench_num!(i64, MAX, read_i64, write_i64, 8, [1, 2, 3, 4, 5, 6, 7, 8]);
+bench_num!(f32, MAX, read_f32, write_f32, 4, [1, 2, 3, 4]);
+bench_num!(f64, MAX, read_f64, write_f64, 8,
+           [1, 2, 3, 4, 5, 6, 7, 8]);
+
+bench_num!(uint_1, read_uint, 1, [1]);
+bench_num!(uint_2, read_uint, 2, [1, 2]);
+bench_num!(uint_3, read_uint, 3, [1, 2, 3]);
+bench_num!(uint_4, read_uint, 4, [1, 2, 3, 4]);
+bench_num!(uint_5, read_uint, 5, [1, 2, 3, 4, 5]);
+bench_num!(uint_6, read_uint, 6, [1, 2, 3, 4, 5, 6]);
+bench_num!(uint_7, read_uint, 7, [1, 2, 3, 4, 5, 6, 7]);
+bench_num!(uint_8, read_uint, 8, [1, 2, 3, 4, 5, 6, 7, 8]);
+
+bench_num!(int_1, read_int, 1, [1]);
+bench_num!(int_2, read_int, 2, [1, 2]);
+bench_num!(int_3, read_int, 3, [1, 2, 3]);
+bench_num!(int_4, read_int, 4, [1, 2, 3, 4]);
+bench_num!(int_5, read_int, 5, [1, 2, 3, 4, 5]);
+bench_num!(int_6, read_int, 6, [1, 2, 3, 4, 5, 6]);
+bench_num!(int_7, read_int, 7, [1, 2, 3, 4, 5, 6, 7]);
+bench_num!(int_8, read_int, 8, [1, 2, 3, 4, 5, 6, 7, 8]);
+
+#[cfg(feature = "i128")]
+bench_num!(u128, MAX, read_u128, write_u128,
+    16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+#[cfg(feature = "i128")]
+bench_num!(i128, MAX, read_i128, write_i128,
+    16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+#[cfg(feature = "i128")]
+bench_num!(uint128_1, read_uint128,
+    1, [1]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_2, read_uint128,
+    2, [1, 2]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_3, read_uint128,
+    3, [1, 2, 3]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_4, read_uint128,
+    4, [1, 2, 3, 4]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_5, read_uint128,
+    5, [1, 2, 3, 4, 5]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_6, read_uint128,
+    6, [1, 2, 3, 4, 5, 6]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_7, read_uint128,
+    7, [1, 2, 3, 4, 5, 6, 7]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_8, read_uint128,
+    8, [1, 2, 3, 4, 5, 6, 7, 8]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_9, read_uint128,
+    9, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_10, read_uint128,
+    10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_11, read_uint128,
+    11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_12, read_uint128,
+    12, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_13, read_uint128,
+    13, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_14, read_uint128,
+    14, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_15, read_uint128,
+    15, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+#[cfg(feature = "i128")]
+bench_num!(uint128_16, read_uint128,
+    16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+#[cfg(feature = "i128")]
+bench_num!(int128_1, read_int128,
+    1, [1]);
+#[cfg(feature = "i128")]
+bench_num!(int128_2, read_int128,
+    2, [1, 2]);
+#[cfg(feature = "i128")]
+bench_num!(int128_3, read_int128,
+    3, [1, 2, 3]);
+#[cfg(feature = "i128")]
+bench_num!(int128_4, read_int128,
+    4, [1, 2, 3, 4]);
+#[cfg(feature = "i128")]
+bench_num!(int128_5, read_int128,
+    5, [1, 2, 3, 4, 5]);
+#[cfg(feature = "i128")]
+bench_num!(int128_6, read_int128,
+    6, [1, 2, 3, 4, 5, 6]);
+#[cfg(feature = "i128")]
+bench_num!(int128_7, read_int128,
+    7, [1, 2, 3, 4, 5, 6, 7]);
+#[cfg(feature = "i128")]
+bench_num!(int128_8, read_int128,
+    8, [1, 2, 3, 4, 5, 6, 7, 8]);
+#[cfg(feature = "i128")]
+bench_num!(int128_9, read_int128,
+    9, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+#[cfg(feature = "i128")]
+bench_num!(int128_10, read_int128,
+    10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+#[cfg(feature = "i128")]
+bench_num!(int128_11, read_int128,
+    11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+#[cfg(feature = "i128")]
+bench_num!(int128_12, read_int128,
+    12, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+#[cfg(feature = "i128")]
+bench_num!(int128_13, read_int128,
+    13, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+#[cfg(feature = "i128")]
+bench_num!(int128_14, read_int128,
+    14, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+#[cfg(feature = "i128")]
+bench_num!(int128_15, read_int128,
+    15, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+#[cfg(feature = "i128")]
+bench_num!(int128_16, read_int128,
+    16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+macro_rules! bench_slice {
+    ($name:ident, $numty:ty, $read:ident, $write:ident) => {
+        pub mod $name {
+            use std::mem::size_of;
+
+            use byteorder::{ByteOrder, BigEndian, LittleEndian};
+            use rand::{self, Rng};
+            use rand::distributions;
+
+            wrap_libtest! {
+                $name,
+                fn read_big_endian(b: &mut Bencher) {
+                    let mut numbers: Vec<$numty> = rand::thread_rng()
+                        .sample_iter(&distributions::Standard)
+                        .take(100000)
+                        .collect();
+                    let mut bytes = vec![0; numbers.len() * size_of::<$numty>()];
+                    BigEndian::$write(&numbers, &mut bytes);
+
+                    // b.bytes = bytes.len() as u64;  // test::Bencher uses this for MB/s
+                    b.iter(|| {
+                        BigEndian::$read(&bytes, &mut numbers);
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $name,
+                fn read_little_endian(b: &mut Bencher) {
+                    let mut numbers: Vec<$numty> = rand::thread_rng()
+                        .sample_iter(&distributions::Standard)
+                        .take(100000)
+                        .collect();
+                    let mut bytes = vec![0; numbers.len() * size_of::<$numty>()];
+                    LittleEndian::$write(&numbers, &mut bytes);
+
+                    // b.bytes = bytes.len() as u64;  // test::Bencher uses this for MB/s
+                    b.iter(|| {
+                        LittleEndian::$read(&bytes, &mut numbers);
+                    });
+                }
+            }
+
+            
+            wrap_libtest! {
+                $name,
+                fn write_big_endian(b: &mut Bencher) {
+                    let numbers: Vec<$numty> = rand::thread_rng()
+                        .sample_iter(&distributions::Standard)
+                        .take(100000)
+                        .collect();
+                    let mut bytes = vec![0; numbers.len() * size_of::<$numty>()];
+
+                    // b.bytes = bytes.len() as u64;  // test::Bencher uses this for MB/s
+                    b.iter(|| {
+                        BigEndian::$write(&numbers, &mut bytes);
+                    });
+                }
+            }
+
+            wrap_libtest! {
+                $name,
+                fn write_little_endian(b: &mut Bencher) {
+                    let numbers: Vec<$numty> = rand::thread_rng()
+                        .sample_iter(&distributions::Standard)
+                        .take(100000)
+                        .collect();
+                    let mut bytes = vec![0; numbers.len() * size_of::<$numty>()];
+
+                    // b.bytes = bytes.len() as u64;  // test::Bencher uses this for MB/s
+                    b.iter(|| {
+                    LittleEndian::$write(&numbers, &mut bytes);
+                    });
+                }
+            }
+        }
+    }
+}
+
+bench_slice!(slice_u64, u64, read_u64_into, write_u64_into);

--- a/benches/byteorder_1_2_6/tests/f32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f32::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/f64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/f64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "f64::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i128-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i128-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i128::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i16-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i16-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i16::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i32::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/i64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/i64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "i64::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_1::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_1::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_1::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_2::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_2::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_2::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_3::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_3::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_3::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_4::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_4::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_4::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_5::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_5::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_5::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_6::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_6::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_6::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_7::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_7::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_7::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_8::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_8::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int_8::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_1::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_1::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_1::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-10-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-10-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_10::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-10-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-10-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_10::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-10-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-10-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_10::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-11-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-11-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_11::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-11-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-11-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_11::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-11-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-11-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_11::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-12-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-12-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_12::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-12-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-12-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_12::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-12-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-12-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_12::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-13-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-13-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_13::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-13-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-13-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_13::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-13-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-13-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_13::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-14-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-14-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_14::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-14-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-14-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_14::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-14-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-14-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_14::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-15-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-15-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_15::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-15-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-15-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_15::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-15-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-15-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_15::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_16::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_16::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_16::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_2::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_2::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_2::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_3::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_3::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_3::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_4::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_4::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_4::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_5::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_5::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_5::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_6::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_6::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_6::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_7::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_7::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_7::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_8::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_8::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_8::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-9-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-9-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_9::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-9-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-9-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_9::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/int128-9-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/int128-9-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "int128_9::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/slice-u64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/slice-u64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "slice_u64::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/slice-u64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/slice-u64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "slice_u64::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/slice-u64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/slice-u64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "slice_u64::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/slice-u64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/slice-u64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "slice_u64::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u128-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u128-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u128::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u16-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u16-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u16::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u32-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u32-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u32::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-write-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-write-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::write_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-write-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-write-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::write_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/u64-write-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/u64-write-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "u64::write_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_1::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_1::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_1::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_2::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_2::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_2::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_3::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_3::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_3::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_4::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_4::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_4::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_5::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_5::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_5::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_6::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_6::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_6::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_7::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_7::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_7::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_8::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_8::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint_8::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-1-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-1-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_1::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-1-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-1-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_1::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-1-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-1-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_1::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-10-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-10-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_10::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-10-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-10-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_10::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-10-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-10-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_10::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-11-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-11-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_11::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-11-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-11-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_11::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-11-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-11-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_11::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-12-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-12-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_12::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-12-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-12-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_12::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-12-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-12-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_12::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-13-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-13-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_13::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-13-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-13-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_13::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-13-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-13-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_13::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-14-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-14-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_14::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-14-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-14-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_14::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-14-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-14-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_14::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-15-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-15-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_15::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-15-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-15-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_15::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-15-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-15-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_15::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-16-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-16-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_16::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-16-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-16-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_16::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-16-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-16-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_16::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-2-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-2-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_2::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-2-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-2-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_2::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-2-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-2-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_2::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-3-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-3-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_3::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-3-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-3-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_3::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-3-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-3-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_3::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-4-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-4-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_4::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-4-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-4-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_4::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-4-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-4-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_4::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-5-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-5-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_5::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-5-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-5-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_5::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-5-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-5-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_5::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-6-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-6-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_6::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-6-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-6-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_6::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-6-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-6-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_6::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-7-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-7-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_7::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-7-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-7-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_7::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-7-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-7-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_7::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-8-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-8-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_8::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-8-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-8-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_8::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-8-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-8-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_8::read_native_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-9-read-big-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-9-read-big-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_9::read_big_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-9-read-little-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-9-read-little-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_9::read_little_endian" , ) ; }

--- a/benches/byteorder_1_2_6/tests/uint128-9-read-native-endian.rs
+++ b/benches/byteorder_1_2_6/tests/uint128-9-read-native-endian.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "byteorder_1_2_6" , "uint128_9::read_native_endian" , ) ; }

--- a/registry.toml
+++ b/registry.toml
@@ -33,6 +33,1056 @@ name = 'bench_e2e_rt_q9_5_1024k'
 crate = 'brotli_1_1_3'
 entrypoint_path = 'benches/brotli_1_1_3/src/bin/bench-e2e-rt-q9-5-1024k.rs'
 
+[benchmarks."byteorder_1_2_6::f32::read_big_endian"]
+name = 'f32::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f32::read_little_endian"]
+name = 'f32::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f32::read_native_endian"]
+name = 'f32::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f32::write_big_endian"]
+name = 'f32::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f32::write_little_endian"]
+name = 'f32::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f32::write_native_endian"]
+name = 'f32::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f32-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::read_big_endian"]
+name = 'f64::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::read_little_endian"]
+name = 'f64::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::read_native_endian"]
+name = 'f64::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::write_big_endian"]
+name = 'f64::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::write_little_endian"]
+name = 'f64::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::f64::write_native_endian"]
+name = 'f64::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/f64-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::read_big_endian"]
+name = 'i128::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::read_little_endian"]
+name = 'i128::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::read_native_endian"]
+name = 'i128::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::write_big_endian"]
+name = 'i128::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::write_little_endian"]
+name = 'i128::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i128::write_native_endian"]
+name = 'i128::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i128-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::read_big_endian"]
+name = 'i16::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::read_little_endian"]
+name = 'i16::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::read_native_endian"]
+name = 'i16::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::write_big_endian"]
+name = 'i16::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::write_little_endian"]
+name = 'i16::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i16::write_native_endian"]
+name = 'i16::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i16-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::read_big_endian"]
+name = 'i32::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::read_little_endian"]
+name = 'i32::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::read_native_endian"]
+name = 'i32::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::write_big_endian"]
+name = 'i32::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::write_little_endian"]
+name = 'i32::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i32::write_native_endian"]
+name = 'i32::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i32-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::read_big_endian"]
+name = 'i64::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::read_little_endian"]
+name = 'i64::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::read_native_endian"]
+name = 'i64::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::write_big_endian"]
+name = 'i64::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::write_little_endian"]
+name = 'i64::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::i64::write_native_endian"]
+name = 'i64::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/i64-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_10::read_big_endian"]
+name = 'int128_10::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-10-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_10::read_little_endian"]
+name = 'int128_10::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-10-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_10::read_native_endian"]
+name = 'int128_10::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-10-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_11::read_big_endian"]
+name = 'int128_11::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-11-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_11::read_little_endian"]
+name = 'int128_11::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-11-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_11::read_native_endian"]
+name = 'int128_11::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-11-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_12::read_big_endian"]
+name = 'int128_12::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-12-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_12::read_little_endian"]
+name = 'int128_12::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-12-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_12::read_native_endian"]
+name = 'int128_12::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-12-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_13::read_big_endian"]
+name = 'int128_13::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-13-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_13::read_little_endian"]
+name = 'int128_13::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-13-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_13::read_native_endian"]
+name = 'int128_13::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-13-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_14::read_big_endian"]
+name = 'int128_14::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-14-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_14::read_little_endian"]
+name = 'int128_14::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-14-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_14::read_native_endian"]
+name = 'int128_14::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-14-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_15::read_big_endian"]
+name = 'int128_15::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-15-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_15::read_little_endian"]
+name = 'int128_15::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-15-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_15::read_native_endian"]
+name = 'int128_15::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-15-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_16::read_big_endian"]
+name = 'int128_16::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-16-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_16::read_little_endian"]
+name = 'int128_16::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-16-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_16::read_native_endian"]
+name = 'int128_16::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-16-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_1::read_big_endian"]
+name = 'int128_1::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-1-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_1::read_little_endian"]
+name = 'int128_1::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-1-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_1::read_native_endian"]
+name = 'int128_1::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-1-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_2::read_big_endian"]
+name = 'int128_2::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-2-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_2::read_little_endian"]
+name = 'int128_2::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-2-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_2::read_native_endian"]
+name = 'int128_2::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-2-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_3::read_big_endian"]
+name = 'int128_3::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-3-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_3::read_little_endian"]
+name = 'int128_3::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-3-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_3::read_native_endian"]
+name = 'int128_3::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-3-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_4::read_big_endian"]
+name = 'int128_4::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-4-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_4::read_little_endian"]
+name = 'int128_4::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-4-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_4::read_native_endian"]
+name = 'int128_4::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-4-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_5::read_big_endian"]
+name = 'int128_5::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-5-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_5::read_little_endian"]
+name = 'int128_5::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-5-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_5::read_native_endian"]
+name = 'int128_5::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-5-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_6::read_big_endian"]
+name = 'int128_6::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-6-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_6::read_little_endian"]
+name = 'int128_6::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-6-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_6::read_native_endian"]
+name = 'int128_6::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-6-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_7::read_big_endian"]
+name = 'int128_7::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-7-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_7::read_little_endian"]
+name = 'int128_7::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-7-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_7::read_native_endian"]
+name = 'int128_7::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-7-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_8::read_big_endian"]
+name = 'int128_8::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-8-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_8::read_little_endian"]
+name = 'int128_8::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-8-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_8::read_native_endian"]
+name = 'int128_8::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-8-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_9::read_big_endian"]
+name = 'int128_9::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-9-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_9::read_little_endian"]
+name = 'int128_9::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-9-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int128_9::read_native_endian"]
+name = 'int128_9::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int128-9-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_1::read_big_endian"]
+name = 'int_1::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-1-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_1::read_little_endian"]
+name = 'int_1::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-1-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_1::read_native_endian"]
+name = 'int_1::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-1-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_2::read_big_endian"]
+name = 'int_2::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-2-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_2::read_little_endian"]
+name = 'int_2::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-2-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_2::read_native_endian"]
+name = 'int_2::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-2-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_3::read_big_endian"]
+name = 'int_3::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-3-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_3::read_little_endian"]
+name = 'int_3::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-3-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_3::read_native_endian"]
+name = 'int_3::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-3-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_4::read_big_endian"]
+name = 'int_4::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-4-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_4::read_little_endian"]
+name = 'int_4::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-4-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_4::read_native_endian"]
+name = 'int_4::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-4-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_5::read_big_endian"]
+name = 'int_5::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-5-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_5::read_little_endian"]
+name = 'int_5::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-5-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_5::read_native_endian"]
+name = 'int_5::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-5-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_6::read_big_endian"]
+name = 'int_6::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-6-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_6::read_little_endian"]
+name = 'int_6::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-6-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_6::read_native_endian"]
+name = 'int_6::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-6-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_7::read_big_endian"]
+name = 'int_7::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-7-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_7::read_little_endian"]
+name = 'int_7::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-7-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_7::read_native_endian"]
+name = 'int_7::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-7-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_8::read_big_endian"]
+name = 'int_8::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-8-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_8::read_little_endian"]
+name = 'int_8::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-8-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::int_8::read_native_endian"]
+name = 'int_8::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/int-8-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::slice_u64::read_big_endian"]
+name = 'slice_u64::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/slice-u64-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::slice_u64::read_little_endian"]
+name = 'slice_u64::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/slice-u64-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::slice_u64::write_big_endian"]
+name = 'slice_u64::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/slice-u64-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::slice_u64::write_little_endian"]
+name = 'slice_u64::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/slice-u64-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::read_big_endian"]
+name = 'u128::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::read_little_endian"]
+name = 'u128::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::read_native_endian"]
+name = 'u128::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::write_big_endian"]
+name = 'u128::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::write_little_endian"]
+name = 'u128::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u128::write_native_endian"]
+name = 'u128::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u128-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::read_big_endian"]
+name = 'u16::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::read_little_endian"]
+name = 'u16::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::read_native_endian"]
+name = 'u16::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::write_big_endian"]
+name = 'u16::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::write_little_endian"]
+name = 'u16::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u16::write_native_endian"]
+name = 'u16::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u16-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::read_big_endian"]
+name = 'u32::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::read_little_endian"]
+name = 'u32::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::read_native_endian"]
+name = 'u32::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::write_big_endian"]
+name = 'u32::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::write_little_endian"]
+name = 'u32::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u32::write_native_endian"]
+name = 'u32::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u32-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::read_big_endian"]
+name = 'u64::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::read_little_endian"]
+name = 'u64::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::read_native_endian"]
+name = 'u64::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::write_big_endian"]
+name = 'u64::write_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-write-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::write_little_endian"]
+name = 'u64::write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::u64::write_native_endian"]
+name = 'u64::write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/u64-write-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_10::read_big_endian"]
+name = 'uint128_10::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-10-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_10::read_little_endian"]
+name = 'uint128_10::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-10-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_10::read_native_endian"]
+name = 'uint128_10::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-10-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_11::read_big_endian"]
+name = 'uint128_11::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-11-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_11::read_little_endian"]
+name = 'uint128_11::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-11-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_11::read_native_endian"]
+name = 'uint128_11::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-11-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_12::read_big_endian"]
+name = 'uint128_12::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-12-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_12::read_little_endian"]
+name = 'uint128_12::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-12-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_12::read_native_endian"]
+name = 'uint128_12::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-12-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_13::read_big_endian"]
+name = 'uint128_13::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-13-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_13::read_little_endian"]
+name = 'uint128_13::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-13-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_13::read_native_endian"]
+name = 'uint128_13::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-13-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_14::read_big_endian"]
+name = 'uint128_14::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-14-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_14::read_little_endian"]
+name = 'uint128_14::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-14-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_14::read_native_endian"]
+name = 'uint128_14::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-14-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_15::read_big_endian"]
+name = 'uint128_15::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-15-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_15::read_little_endian"]
+name = 'uint128_15::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-15-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_15::read_native_endian"]
+name = 'uint128_15::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-15-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_16::read_big_endian"]
+name = 'uint128_16::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-16-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_16::read_little_endian"]
+name = 'uint128_16::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-16-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_16::read_native_endian"]
+name = 'uint128_16::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-16-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_1::read_big_endian"]
+name = 'uint128_1::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-1-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_1::read_little_endian"]
+name = 'uint128_1::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-1-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_1::read_native_endian"]
+name = 'uint128_1::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-1-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_2::read_big_endian"]
+name = 'uint128_2::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-2-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_2::read_little_endian"]
+name = 'uint128_2::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-2-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_2::read_native_endian"]
+name = 'uint128_2::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-2-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_3::read_big_endian"]
+name = 'uint128_3::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-3-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_3::read_little_endian"]
+name = 'uint128_3::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-3-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_3::read_native_endian"]
+name = 'uint128_3::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-3-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_4::read_big_endian"]
+name = 'uint128_4::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-4-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_4::read_little_endian"]
+name = 'uint128_4::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-4-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_4::read_native_endian"]
+name = 'uint128_4::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-4-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_5::read_big_endian"]
+name = 'uint128_5::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-5-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_5::read_little_endian"]
+name = 'uint128_5::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-5-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_5::read_native_endian"]
+name = 'uint128_5::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-5-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_6::read_big_endian"]
+name = 'uint128_6::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-6-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_6::read_little_endian"]
+name = 'uint128_6::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-6-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_6::read_native_endian"]
+name = 'uint128_6::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-6-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_7::read_big_endian"]
+name = 'uint128_7::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-7-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_7::read_little_endian"]
+name = 'uint128_7::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-7-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_7::read_native_endian"]
+name = 'uint128_7::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-7-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_8::read_big_endian"]
+name = 'uint128_8::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-8-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_8::read_little_endian"]
+name = 'uint128_8::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-8-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_8::read_native_endian"]
+name = 'uint128_8::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-8-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_9::read_big_endian"]
+name = 'uint128_9::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-9-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_9::read_little_endian"]
+name = 'uint128_9::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-9-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint128_9::read_native_endian"]
+name = 'uint128_9::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint128-9-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_1::read_big_endian"]
+name = 'uint_1::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-1-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_1::read_little_endian"]
+name = 'uint_1::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-1-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_1::read_native_endian"]
+name = 'uint_1::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-1-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_2::read_big_endian"]
+name = 'uint_2::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-2-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_2::read_little_endian"]
+name = 'uint_2::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-2-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_2::read_native_endian"]
+name = 'uint_2::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-2-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_3::read_big_endian"]
+name = 'uint_3::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-3-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_3::read_little_endian"]
+name = 'uint_3::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-3-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_3::read_native_endian"]
+name = 'uint_3::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-3-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_4::read_big_endian"]
+name = 'uint_4::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-4-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_4::read_little_endian"]
+name = 'uint_4::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-4-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_4::read_native_endian"]
+name = 'uint_4::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-4-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_5::read_big_endian"]
+name = 'uint_5::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-5-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_5::read_little_endian"]
+name = 'uint_5::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-5-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_5::read_native_endian"]
+name = 'uint_5::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-5-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_6::read_big_endian"]
+name = 'uint_6::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-6-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_6::read_little_endian"]
+name = 'uint_6::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-6-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_6::read_native_endian"]
+name = 'uint_6::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-6-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_7::read_big_endian"]
+name = 'uint_7::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-7-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_7::read_little_endian"]
+name = 'uint_7::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-7-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_7::read_native_endian"]
+name = 'uint_7::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-7-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_8::read_big_endian"]
+name = 'uint_8::read_big_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-8-read-big-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_8::read_little_endian"]
+name = 'uint_8::read_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-8-read-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::uint_8::read_native_endian"]
+name = 'uint_8::read_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/uint-8-read-native-endian.rs'
+
+[benchmarks."byteorder_1_2_6::write_little_endian"]
+name = 'write_little_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/write-little-endian.rs'
+
+[benchmarks."byteorder_1_2_6::write_native_endian"]
+name = 'write_native_endian'
+crate = 'byteorder_1_2_6'
+entrypoint_path = 'benches/byteorder_1_2_6/src/bin/write-native-endian.rs'
+
 [benchmarks."crossbeam_epoch_0_4_0::defer::multi_alloc_defer_free"]
 runner = 'sally'
 name = 'defer::multi_alloc_defer_free'


### PR DESCRIPTION
This PR includes benchmarks from the byteorder 1.2.6 crate.