### PR TITLE
Create licenses

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Adam Perry and lolbench contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Adam Perry and lolbench contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/anp/lolbench/tree/master.svg?style=shield)](https://circleci.com/gh/anp/workflows/lolbench)
 
-This project is an effort to reproducibly benchmark "in the wild" Rust code against newer compiler versions to detect performance regressions. Still a WIP for the moment, but many are the larger building blocks are in place.
+This project is an effort to reproducibly benchmark "in the wild" Rust code against newer compiler versions to detect performance regressions. The data is currently published to [https://blog.anp.lol/lolbench-data](https://blog.anp.lol/lolbench-data).
 
 ## Adding Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ $ cargo test-core
 * `cargo new-bench-crate` runs a lolbench command to create a new benchmark crate in the benches directory.
 * `cargo build-all [--release]` builds a binary for every benchmark function. *caution: this will generate dozens of gigabytes of data in your target directory*.
 * `cargo test-all [--release]` runs the test for every benchmark function, which consists of warming it up and running through a couple of iterations. *caution: this will generate dozens of gigabytes of data in your target directory*.
+
+## License
+
+lolbench is distributed under the terms of both the MIT license and the Apache License (Version 2.0). Some included benchmarks have their own separate licenses, see those directories and their Cargo.toml metadata for details.

--- a/benches/brotli_1_1_3/Cargo.toml
+++ b/benches/brotli_1_1_3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brotli_1_1_3"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "BSD-3-Clause/MIT"
 
 [dependencies]
 alloc-no-stdlib = "1.2"

--- a/benches/byteorder_1_2_6/Cargo.toml
+++ b/benches/byteorder_1_2_6/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "byteorder_1_2_6"
 version = "0.1.0"
-authors = ['Thom wiggers <thom@thomwiggers.nl>']
+license = "Unlicense/MIT"
 
 [dependencies]
 byteorder = "=1.2.6"

--- a/benches/crossbeam_epoch_0_4_0/Cargo.toml
+++ b/benches/crossbeam_epoch_0_4_0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossbeam_epoch_0_4_0"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "MIT/Apache-2.0"
 
 [dependencies]
 crossbeam-epoch = "0.4.0"

--- a/benches/csv_1_0_2/Cargo.toml
+++ b/benches/csv_1_0_2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "csv_1_0_2"
 version = "0.1.0"
 authors = []
+license = "Unlicense/MIT"
 
 [dependencies]
 csv = "=1.0.2"

--- a/benches/diesel_1_1_1/Cargo.toml
+++ b/benches/diesel_1_1_1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diesel_1_1_1"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 criterion = { version = "*", path = "../../criterion" }

--- a/benches/inflate_0_3_4/Cargo.toml
+++ b/benches/inflate_0_3_4/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "inflate_0_3_4"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "MIT"
 
 [dependencies]
 inflate = "0.3.4"

--- a/benches/json_benchmark_c7d3d9b/Cargo.toml
+++ b/benches/json_benchmark_c7d3d9b/Cargo.toml
@@ -3,6 +3,7 @@ name = "json_benchmark_c7d3d9b"
 version = "0.0.1"
 authors = ["dtolnay@gmail.com"]
 publish = false
+license = "MIT/Apache-2.0"
 
 [dependencies]
 rustc-serialize = "0.3.24"

--- a/benches/nom_4_0_0/Cargo.toml
+++ b/benches/nom_4_0_0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nom_4_0_0"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "MIT"
 
 [dependencies]
 nom = "4.0.0"

--- a/benches/quickcheck_0_6_1/Cargo.toml
+++ b/benches/quickcheck_0_6_1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickcheck_0_6_1"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "Unlicense/MIT"
 
 [dependencies]
 quickcheck = "0.6.1"

--- a/benches/rayon_1_0_0/Cargo.toml
+++ b/benches/rayon_1_0_0/Cargo.toml
@@ -3,6 +3,7 @@ name = "rayon_1_0_0"
 version = "0.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 publish = false
+license = "Apache-2.0/MIT"
 
 [dependencies]
 rayon = "1.0.0"

--- a/benches/snap_0_2_4/Cargo.toml
+++ b/benches/snap_0_2_4/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snap_0_2_4"
 version = "0.1.0"
-authors = ["Adam Perry <adam.n.perry@gmail.com>"]
+license = "BSD-3-Clause"
 
 [dependencies]
 lazy_static = "0.1"


### PR DESCRIPTION
I made a bit of an oversight here! I forgot to clarify the licensing situation for the code in this repo, namely that the contents of the benches directory can't be assumed to come under the same license as the rest of the code. I've set the license for the non-benchmark-suite parts of the project to dual MIT/Apache 2.0 as is common in the Rust community.

I also realized that I'd set a pretty bad example by leaving my name in the author field for a lot of the benchmark crates which were really authored by someone else. I figure it's easiest if we just say that unless you're copying the Cargo.toml from the original crate that we'll just leave the author field off of bench crates Cargo.toml to avoid any confusion.

cc @shssoichiro and @thomwiggers -- sorry to bother you both. I'll merge this some time Monday pacific US time if I haven't heard back, but I'm assuming this should be an uncontentious change.