### PR TITLE
Add benchmarks for RustCrypto SHA2 and SHA3 0.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,10 @@ jobs:
     <<: *bench_crate
   quickcheck_0_6_1:
     <<: *bench_crate
+  sha2_0_8_0:
+    <<: *bench_crate
+  sha3_0_8_0:
+    <<: *bench_crate
   snap_0_2_4:
     <<: *bench_crate
   csv_1_0_2:
@@ -169,6 +173,12 @@ workflows:
           requires:
             - fmt
       - quickcheck_0_6_1:
+          requires:
+            - fmt
+      - sha2_0_8_0:
+          requires:
+            - fmt
+      - sha3_0_8_0:
           requires:
             - fmt
       - snap_0_2_4:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "brotli"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +243,11 @@ dependencies = [
 [[package]]
 name = "byte-tools"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -649,6 +673,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dlib"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +838,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "generic-array"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1021,6 +1061,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,10 +1254,10 @@ dependencies = [
 name = "marky_mark"
 version = "0.1.0"
 dependencies = [
- "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1450,6 +1495,11 @@ dependencies = [
  "rawslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unchecked-index 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-probe"
@@ -1914,6 +1964,49 @@ dependencies = [
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2_0_8_0"
+version = "0.1.0"
+dependencies = [
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lolbench 0.0.1",
+ "lolbench_support 0.1.0",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3_0_8_0"
+version = "0.1.0"
+dependencies = [
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lolbench 0.0.1",
+ "lolbench_support 0.1.0",
+ "sha3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2558,9 +2651,12 @@ dependencies = [
 "checksum bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b2bf7093258c32e0825b635948de528a5949799dcd61bef39534c8aab95870c"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"
 "checksum brotli 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "63ed32a4ebe7fbd0f95c11b69fb953807b59baa7ecf0afd610ec29f18f8e5f28"
 "checksum brotli-decompressor 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "358f28e94689d14c621de44c6813555abeadf0c95c3e1f3f13943deb9eb98dc8"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
@@ -2596,6 +2692,7 @@ dependencies = [
 "checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
 "checksum diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42c35d1ce9e8d57a3e7001b4127f2bc1b073a89708bb7019f5be27c991c28"
 "checksum digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b29c278aa8fd30796bd977169e8004b4aa88cdcd2f32a6eb22bc2d5d38df94a"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
@@ -2613,6 +2710,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
@@ -2630,6 +2728,7 @@ dependencies = [
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d78fa608383e6e608ba36f962ac991d5d6878d7203eb93b4711b14fa6717813"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+"checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
@@ -2670,6 +2769,7 @@ dependencies = [
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
 "checksum odds 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9a18d7081eb052145753e982d7b8de495f15f74636d0d963f09116581eab665"
+"checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
@@ -2719,6 +2819,8 @@ dependencies = [
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum sha3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3dc112cab364efe7b2542fb884920b8b59cc8b52d6b3ab0957b26ffa64bc9a"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum signal-hook 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc9a251608ddaef559cd5b08b539cbda8c36d0efe0506f9a864765d75dbd665"
 "checksum simple_logger 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c0619150c42143a91bd79aa00b5f01f9b0a3ec38b1a59bc0b2f5aa24fc4c9bd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,5 +69,7 @@ members = [
     "./benches/rayon_1_0_0",
     "./benches/raytrace_8de9020",
     "./benches/regex_0_2_6",
+    "./benches/sha2_0_8_0",
+    "./benches/sha3_0_8_0",
     "./benches/snap_0_2_4"
 ]

--- a/benches/sha2_0_8_0/Cargo.toml
+++ b/benches/sha2_0_8_0/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sha2_0_8_0"
+version = "0.1.0"
+authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
+license = "MIT/Apache-2.0"
+
+[dependencies]
+lolbench_support = { path = "../../support" }
+sha2 = "=0.8.0"
+digest = "=0.8.0"
+
+[dev-dependencies]
+lolbench = { path = "../../" }
+
+[features]
+default = ["std"]
+std = ["digest/std"]

--- a/benches/sha2_0_8_0/src/bin/sha256-bench1-10.rs
+++ b/benches/sha2_0_8_0/src/bin/sha256-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha256 :: bench1_10 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha256-bench2-100.rs
+++ b/benches/sha2_0_8_0/src/bin/sha256-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha256 :: bench2_100 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha256-bench3-1000.rs
+++ b/benches/sha2_0_8_0/src/bin/sha256-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha256 :: bench3_1000 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha256-bench4-10000.rs
+++ b/benches/sha2_0_8_0/src/bin/sha256-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha256 :: bench4_10000 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha512-bench1-10.rs
+++ b/benches/sha2_0_8_0/src/bin/sha512-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha512 :: bench1_10 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha512-bench2-100.rs
+++ b/benches/sha2_0_8_0/src/bin/sha512-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha512 :: bench2_100 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha512-bench3-1000.rs
+++ b/benches/sha2_0_8_0/src/bin/sha512-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha512 :: bench3_1000 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/bin/sha512-bench4-10000.rs
+++ b/benches/sha2_0_8_0/src/bin/sha512-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate sha2_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha2_0_8_0 :: sha512 :: bench4_10000 ( & mut crit ) ; }

--- a/benches/sha2_0_8_0/src/lib.rs
+++ b/benches/sha2_0_8_0/src/lib.rs
@@ -1,0 +1,41 @@
+//! This module benchmarks SHA2 hashes.
+//!
+//! It contains a modified version of the Digest crate's bench macro.
+#[macro_use]
+extern crate lolbench_support;
+
+macro_rules! digest_bench {
+    ($module:path, $name:ident, $engine:path, $bs:expr) => {
+        wrap_libtest! {
+            $module,
+            fn $name(b: &mut Bencher) {
+                let mut d = <$engine>::default();
+                let data = [0; $bs];
+
+                b.iter(|| {
+                    d.input(&data[..]);
+                });
+
+                // b.bytes = $bs;
+                // Criterion's bencher does not support MB/s
+            }
+        }
+    };
+
+    ($mod:ident, $engine:path) => {
+        pub mod $mod {
+            extern crate digest;
+            extern crate sha2;
+
+            use self::digest::Digest;
+
+            digest_bench!($mod, bench1_10,    $engine, 10);
+            digest_bench!($mod, bench2_100,   $engine, 100);
+            digest_bench!($mod, bench3_1000,  $engine, 1000);
+            digest_bench!($mod, bench4_10000, $engine, 10000);
+        }
+    };
+}
+
+digest_bench!(sha256, sha2::Sha256);
+digest_bench!(sha512, sha2::Sha512);

--- a/benches/sha2_0_8_0/tests/sha256-bench1-10.rs
+++ b/benches/sha2_0_8_0/tests/sha256-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha256::bench1_10" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha256-bench2-100.rs
+++ b/benches/sha2_0_8_0/tests/sha256-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha256::bench2_100" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha256-bench3-1000.rs
+++ b/benches/sha2_0_8_0/tests/sha256-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha256::bench3_1000" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha256-bench4-10000.rs
+++ b/benches/sha2_0_8_0/tests/sha256-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha256::bench4_10000" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha512-bench1-10.rs
+++ b/benches/sha2_0_8_0/tests/sha512-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha512::bench1_10" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha512-bench2-100.rs
+++ b/benches/sha2_0_8_0/tests/sha512-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha512::bench2_100" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha512-bench3-1000.rs
+++ b/benches/sha2_0_8_0/tests/sha512-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha512::bench3_1000" , ) ; }

--- a/benches/sha2_0_8_0/tests/sha512-bench4-10000.rs
+++ b/benches/sha2_0_8_0/tests/sha512-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha2_0_8_0" , "sha512::bench4_10000" , ) ; }

--- a/benches/sha3_0_8_0/Cargo.toml
+++ b/benches/sha3_0_8_0/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sha3_0_8_0"
+version = "0.1.0"
+authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
+license = "MIT/Apache-2.0"
+
+[dependencies]
+lolbench_support = { path = "../../support" }
+sha3 = "=0.8.0"
+digest = "=0.8.0"
+
+[dev-dependencies]
+lolbench = { path = "../../" }
+
+[features]
+default = ["std"]
+std = ["digest/std"]

--- a/benches/sha3_0_8_0/src/bin/sha3-256-bench1-10.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-256-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_256 :: bench1_10 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-256-bench2-100.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-256-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_256 :: bench2_100 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-256-bench3-1000.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-256-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_256 :: bench3_1000 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-256-bench4-10000.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-256-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_256 :: bench4_10000 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-512-bench1-10.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-512-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_512 :: bench1_10 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-512-bench2-100.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-512-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_512 :: bench2_100 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-512-bench3-1000.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-512-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_512 :: bench3_1000 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/bin/sha3-512-bench4-10000.rs
+++ b/benches/sha3_0_8_0/src/bin/sha3-512-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate sha3_0_8_0 ; extern crate lolbench_support ; use lolbench_support :: { criterion_from_env , init_logging } ; fn main ( ) { init_logging ( ) ; let mut crit = criterion_from_env ( ) ; sha3_0_8_0 :: sha3_512 :: bench4_10000 ( & mut crit ) ; }

--- a/benches/sha3_0_8_0/src/lib.rs
+++ b/benches/sha3_0_8_0/src/lib.rs
@@ -1,0 +1,41 @@
+//! This module benchmarks sha3 hashes.
+//!
+//! It contains a modified version of the Digest crate's bench macro.
+#[macro_use]
+extern crate lolbench_support;
+
+macro_rules! digest_bench {
+    ($module:path, $name:ident, $engine:path, $bs:expr) => {
+        wrap_libtest! {
+            $module,
+            fn $name(b: &mut Bencher) {
+                let mut d = <$engine>::default();
+                let data = [0; $bs];
+
+                b.iter(|| {
+                    d.input(&data[..]);
+                });
+
+                // b.bytes = $bs;
+                // Criterion's bencher does not support MB/s
+            }
+        }
+    };
+
+    ($mod:ident, $engine:path) => {
+        pub mod $mod {
+            extern crate digest;
+            extern crate sha3;
+
+            use self::digest::Digest;
+
+            digest_bench!($mod, bench1_10,    $engine, 10);
+            digest_bench!($mod, bench2_100,   $engine, 100);
+            digest_bench!($mod, bench3_1000,  $engine, 1000);
+            digest_bench!($mod, bench4_10000, $engine, 10000);
+        }
+    };
+}
+
+digest_bench!(sha3_256, sha3::Sha3_256);
+digest_bench!(sha3_512, sha3::Sha3_512);

--- a/benches/sha3_0_8_0/tests/sha3-256-bench1-10.rs
+++ b/benches/sha3_0_8_0/tests/sha3-256-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_256::bench1_10" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-256-bench2-100.rs
+++ b/benches/sha3_0_8_0/tests/sha3-256-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_256::bench2_100" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-256-bench3-1000.rs
+++ b/benches/sha3_0_8_0/tests/sha3-256-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_256::bench3_1000" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-256-bench4-10000.rs
+++ b/benches/sha3_0_8_0/tests/sha3-256-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_256::bench4_10000" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-512-bench1-10.rs
+++ b/benches/sha3_0_8_0/tests/sha3-512-bench1-10.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_512::bench1_10" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-512-bench2-100.rs
+++ b/benches/sha3_0_8_0/tests/sha3-512-bench2-100.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_512::bench2_100" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-512-bench3-1000.rs
+++ b/benches/sha3_0_8_0/tests/sha3-512-bench3-1000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_512::bench3_1000" , ) ; }

--- a/benches/sha3_0_8_0/tests/sha3-512-bench4-10000.rs
+++ b/benches/sha3_0_8_0/tests/sha3-512-bench4-10000.rs
@@ -1,0 +1,1 @@
+extern crate lolbench ; # [ test ] fn end_to_end ( ) { lolbench :: end_to_end_test ( "sha3_0_8_0" , "sha3_512::bench4_10000" , ) ; }

--- a/registry.toml
+++ b/registry.toml
@@ -3229,6 +3229,86 @@ name = 'sherlock::words'
 crate = 'regex_0_2_6'
 entrypoint_path = 'benches/regex_0_2_6/src/bin/sherlock-words.rs'
 
+[benchmarks."sha2_0_8_0::sha256::bench1_10"]
+name = 'sha256::bench1_10'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha256-bench1-10.rs'
+
+[benchmarks."sha2_0_8_0::sha256::bench2_100"]
+name = 'sha256::bench2_100'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha256-bench2-100.rs'
+
+[benchmarks."sha2_0_8_0::sha256::bench3_1000"]
+name = 'sha256::bench3_1000'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha256-bench3-1000.rs'
+
+[benchmarks."sha2_0_8_0::sha256::bench4_10000"]
+name = 'sha256::bench4_10000'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha256-bench4-10000.rs'
+
+[benchmarks."sha2_0_8_0::sha512::bench1_10"]
+name = 'sha512::bench1_10'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha512-bench1-10.rs'
+
+[benchmarks."sha2_0_8_0::sha512::bench2_100"]
+name = 'sha512::bench2_100'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha512-bench2-100.rs'
+
+[benchmarks."sha2_0_8_0::sha512::bench3_1000"]
+name = 'sha512::bench3_1000'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha512-bench3-1000.rs'
+
+[benchmarks."sha2_0_8_0::sha512::bench4_10000"]
+name = 'sha512::bench4_10000'
+crate = 'sha2_0_8_0'
+entrypoint_path = 'benches/sha2_0_8_0/src/bin/sha512-bench4-10000.rs'
+
+[benchmarks."sha3_0_8_0::sha3_256::bench1_10"]
+name = 'sha3_256::bench1_10'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-256-bench1-10.rs'
+
+[benchmarks."sha3_0_8_0::sha3_256::bench2_100"]
+name = 'sha3_256::bench2_100'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-256-bench2-100.rs'
+
+[benchmarks."sha3_0_8_0::sha3_256::bench3_1000"]
+name = 'sha3_256::bench3_1000'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-256-bench3-1000.rs'
+
+[benchmarks."sha3_0_8_0::sha3_256::bench4_10000"]
+name = 'sha3_256::bench4_10000'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-256-bench4-10000.rs'
+
+[benchmarks."sha3_0_8_0::sha3_512::bench1_10"]
+name = 'sha3_512::bench1_10'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-512-bench1-10.rs'
+
+[benchmarks."sha3_0_8_0::sha3_512::bench2_100"]
+name = 'sha3_512::bench2_100'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-512-bench2-100.rs'
+
+[benchmarks."sha3_0_8_0::sha3_512::bench3_1000"]
+name = 'sha3_512::bench3_1000'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-512-bench3-1000.rs'
+
+[benchmarks."sha3_0_8_0::sha3_512::bench4_10000"]
+name = 'sha3_512::bench4_10000'
+crate = 'sha3_0_8_0'
+entrypoint_path = 'benches/sha3_0_8_0/src/bin/sha3-512-bench4-10000.rs'
+
 [benchmarks."snap_0_2_4::uflat00_html"]
 runner = 'molly'
 name = 'uflat00_html'


### PR DESCRIPTION
It should be possible to copy one of the bench crates and also add e.g. blake2, but this seems enough for now.

ref. #45 