### PR TITLE
[WIP] Add Benchmark for rawloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,16 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "enumn"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.68 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1064,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "glutin"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1160,14 @@ dependencies = [
 [[package]]
 name = "itertools"
 version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1739,6 +1762,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proptest"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1841,14 @@ version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1905,6 +1944,32 @@ dependencies = [
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rawloader"
+version = "0.36.3"
+source = "git+https://github.com/pedrocr/rawloader.git?rev=c793a132fa03e336f8c5c078f01d3ed1a3ee8c07#c793a132fa03e336f8c5c078f01d3ed1a3ee8c07"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enumn 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rawloader_c793a13"
+version = "0.1.0"
+dependencies = [
+ "lolbench 0.0.1",
+ "lolbench_support 0.1.0",
+ "rawloader 0.36.3 (git+https://github.com/pedrocr/rawloader.git?rev=c793a132fa03e336f8c5c078f01d3ed1a3ee8c07)",
 ]
 
 [[package]]
@@ -2421,6 +2486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2694,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2750,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2987,6 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum enumn 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e58b112d5099aa0857c5d05f0eacab86406dd8c0f85fe5d320a13256d29ecf4"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
@@ -3013,6 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gleam 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cae10d7c99d0e77b4766e850a60898a17c1abaf01075531f1066f03dc7dc5fc5"
 "checksum glium 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caeb879467aeeaced452506e7405b887e2a4877c0c52ab0a57ba45f8a0a3b6d6"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "247f825056c99961b6e6e0baef17ca586a50109ab4bba2b370babe1c5d702943"
 "checksum handlebars 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7bdb08e879b8c78ee90f5022d121897c31ea022cb0cc6d13f2158c7a9fbabb1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -3021,6 +3111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9f47468e9a76a6452271efadc88fe865a82be91fe75e6c0c57b87ccea59d4"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itertools-num 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
@@ -3081,6 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro-hack 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "463bf29e7f11344e58c9e01f171470ab15c925c6822ad75028cc1c0e1d1eb63b"
 "checksum proc-macro-hack-impl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 "checksum proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27f275a76b824714046ce0b1e00323e06437e027f2d31b2b6272cae30afaf18d"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
@@ -3088,6 +3180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
@@ -3098,6 +3191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rawloader 0.36.3 (git+https://github.com/pedrocr/rawloader.git?rev=c793a132fa03e336f8c5c078f01d3ed1a3ee8c07)" = "<none>"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum rawslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b23b9f57ea250c6db4b21e2897b43ff08209217ca8260469fae6c0f9ad7e25"
 "checksum rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
@@ -3151,6 +3245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
+"checksum syn 1.0.68 (registry+https://github.com/rust-lang/crates.io-index)" = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f5e3aaa79319573d19938ea38d068056b826db9883a5d47f86c1cecc688f0e"
@@ -3173,6 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
 "checksum unchecked-index 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
@@ -3182,6 +3278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "./benches/json_benchmark_c7d3d9b",
     "./benches/nom_4_0_0",
     "./benches/quickcheck_0_6_1",
+    "./benches/rawloader_c793a13",
     "./benches/rayon_1_0_0",
     "./benches/raytrace_8de9020",
     "./benches/regex_0_2_6",

--- a/benches/rawloader_c793a13/Cargo.toml
+++ b/benches/rawloader_c793a13/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rawloader_c793a13"
+version = "0.1.0"
+license = "LGPL-2.1"
+
+[dependencies]
+lolbench_support = { path = "../../support" }
+
+[dependencies.rawloader]
+version = "*"
+git = "https://github.com/pedrocr/rawloader.git"
+rev = "c793a132fa03e336f8c5c078f01d3ed1a3ee8c07"
+
+[dev-dependencies]
+lolbench = { path = "../../" }

--- a/benches/rawloader_c793a13/LICENSE.md
+++ b/benches/rawloader_c793a13/LICENSE.md
@@ -1,0 +1,9 @@
+IMPORTANT LICENSING NOTE
+========================
+
+This benchmark has two key licensing concerns:
+
+1. The library and benchmark code themselves are distributed under the LGPL 2.1.
+2. The input data used is distributed under the Creative Commons CC-BY License 2.5.
+
+The full text of these licenses is in the `vendor/` directory.

--- a/benches/rawloader_c793a13/src/bin/benchmark.rs
+++ b/benches/rawloader_c793a13/src/bin/benchmark.rs
@@ -1,0 +1,4 @@
+extern crate rawloader_c793a13 ; extern crate lolbench_support ; use
+lolbench_support :: { criterion_from_env , init_logging } ; fn main (  ) {
+init_logging (  ) ; let mut crit = criterion_from_env (  ) ; rawloader_c793a13
+:: benchmark ( & mut crit ) ; }

--- a/benches/rawloader_c793a13/src/lib.rs
+++ b/benches/rawloader_c793a13/src/lib.rs
@@ -1,0 +1,20 @@
+static DOWNLOAD_ERR: &str = "Failed to load test file. Please download it from: \n\
+                             http://www.rawsamples.ch/raws/leica/vlux1/RAW_LEICA_VLUX1.RAW";
+static EXPECTED_FILE: &str = "RAW_LEICA_VLUX1.RAW";
+
+#[macro_use]
+extern crate lolbench_support;
+
+wrap_libtest! {
+    fn benchmark(b: &mut Bencher) {
+        let mut f = std::fs::File::open(EXPECTED_FILE)
+            .expect(&DOWNLOAD_ERR);
+        let buffer = rawloader::Buffer::new(&mut f)
+            .expect("Failed to initialize buffer");
+        let rawloader = rawloader::RawLoader::new();
+        b.iter(|| {
+            let decoder = rawloader.get_decoder(&buffer).unwrap();
+            decoder.image(false).unwrap()
+        })
+    }
+}

--- a/benches/rawloader_c793a13/src/lib.rs
+++ b/benches/rawloader_c793a13/src/lib.rs
@@ -1,6 +1,4 @@
-static DOWNLOAD_ERR: &str = "Failed to load test file. Please download it from: \n\
-                             http://www.rawsamples.ch/raws/leica/vlux1/RAW_LEICA_VLUX1.RAW";
-static EXPECTED_FILE: &str = "RAW_LEICA_VLUX1.RAW";
+static EXPECTED_FILE: &str = "vendor/RAW_LEICA_VLUX1.RAW";
 
 #[macro_use]
 extern crate lolbench_support;
@@ -8,7 +6,7 @@ extern crate lolbench_support;
 wrap_libtest! {
     fn benchmark(b: &mut Bencher) {
         let mut f = std::fs::File::open(EXPECTED_FILE)
-            .expect(&DOWNLOAD_ERR);
+            .expect("Failed to open critical test file");
         let buffer = rawloader::Buffer::new(&mut f)
             .expect("Failed to initialize buffer");
         let rawloader = rawloader::RawLoader::new();

--- a/benches/rawloader_c793a13/tests/benchmark-benchmark.rs
+++ b/benches/rawloader_c793a13/tests/benchmark-benchmark.rs
@@ -1,3 +1,0 @@
-extern crate lolbench ; # [ test ] fn end_to_end (  ) {
-lolbench :: end_to_end_test ( "rawloader_c793a13" , "benchmark::benchmark" , )
-; }

--- a/benches/rawloader_c793a13/tests/benchmark-benchmark.rs
+++ b/benches/rawloader_c793a13/tests/benchmark-benchmark.rs
@@ -1,0 +1,3 @@
+extern crate lolbench ; # [ test ] fn end_to_end (  ) {
+lolbench :: end_to_end_test ( "rawloader_c793a13" , "benchmark::benchmark" , )
+; }

--- a/benches/rawloader_c793a13/tests/benchmark.rs
+++ b/benches/rawloader_c793a13/tests/benchmark.rs
@@ -1,0 +1,2 @@
+extern crate lolbench ; # [ test ] fn end_to_end (  ) {
+lolbench :: end_to_end_test ( "rawloader_c793a13" , "benchmark" , ) ; }

--- a/benches/rawloader_c793a13/tests/decode-decode.rs
+++ b/benches/rawloader_c793a13/tests/decode-decode.rs
@@ -1,0 +1,2 @@
+extern crate lolbench ; # [ test ] fn end_to_end (  ) {
+lolbench :: end_to_end_test ( "rawloader_c793a13" , "decode::decode" , ) ; }

--- a/benches/rawloader_c793a13/tests/decode-decode.rs
+++ b/benches/rawloader_c793a13/tests/decode-decode.rs
@@ -1,2 +1,0 @@
-extern crate lolbench ; # [ test ] fn end_to_end (  ) {
-lolbench :: end_to_end_test ( "rawloader_c793a13" , "decode::decode" , ) ; }

--- a/benches/rawloader_c793a13/vendor/CCBY_25_de.html
+++ b/benches/rawloader_c793a13/vendor/CCBY_25_de.html
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta name="generator" content="HTML Tidy for Cygwin (vers 1st September 2003), see www.w3.org" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<title></title>
+<style type="text/css">
+/*<![CDATA[*/
+        @page { size: 21.59cm 27.94cm; margin-top: 2.54cm; margin-bottom: 2.54cm; margin-left: 3.175cm; margin-right: 3.175cm }
+        table { border-collapse:collapse; border-spacing:0; empty-cells:show }
+        td, th { vertical-align:top; }
+        h1, h2, h3, h4, h5, h6 { clear:both }
+        ol, ul { padding:0; }
+        *.Frame { vertical-align:top; text-align:center; }
+        *.Graphics { vertical-align:top; text-align:center; }
+        *.OLE { vertical-align:top; text-align:center; }
+        *.Caption { margin-top:0.212cm; margin-bottom:0.212cm; font-style:italic; }
+        *.Heading { font-family:Arial; font-size:14pt; margin-top:0.423cm; margin-bottom:0.212cm; }
+        *.Index { }
+        *.List { margin-top:0cm; margin-bottom:0.212cm; }
+        *.P1 { margin-top:0.176cm; margin-bottom:0.176cm; }
+        *.P10 { margin-left:1.259cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:0cm; font-weight:bold; }
+        *.P11 { margin-left:1.259cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-indent:-0.63cm; }
+        *.P12 { margin-left:1.27cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:-0.635cm; }
+        *.P13 { margin-top:0.212cm; margin-bottom:0cm; text-align:justify! important; }
+        *.P14 {
+    margin-top:0.212cm;
+    margin-bottom:0cm;
+    text-align: justify;
+}
+        *.P15 { margin-top:0.212cm; margin-bottom:0cm; }
+        *.P2 { margin-top:0.176cm; margin-bottom:0.176cm; }
+        *.P3 { margin-top:0.176cm; margin-bottom:0.176cm; text-align:left ! important; }
+        *.P4 { margin-top:0.176cm; margin-bottom:0.176cm; }
+        *.P5 { margin-left:1.27cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-indent:-0.635cm; font-weight:bold; }
+        *.P6 { margin-left:2.529cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:-0.63cm; }
+        *.P7 { margin-left:1.259cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:-0.63cm; }
+        *.P8 { margin-left:2.529cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:-0.63cm; }
+        *.P9 { margin-left:2.54cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-align:left ! important; text-indent:0cm; }
+        *.P99 {  text-align:left ! important; margin-left:1.259cm; margin-right:0cm; margin-top:0.212cm; margin-bottom:0cm; text-indent:0cm; }
+        *.Standard { }
+        *.Textbody { margin-top:0cm; margin-bottom:0.212cm; }
+        *.T1 { }
+        *.T2 { font-weight:bold; }
+        *.T3 { font-weight:bold; }
+/*]]>*/
+</style>
+<link rel="stylesheet" type="text/css" href="https://creativecommons.org/includes/deeds.css" />
+<style type="text/css">
+/*<![CDATA[*/
+li { margin-bottom:12px; }
+/*]]>*/
+</style>
+</head>
+<body>
+<p align="center"><a href="/">Creative Commons</a></p>
+<div id="deed">
+<div align="center">
+<img src="https://creativecommons.org/images/deed/logo_code.gif" alt="Creative Commons Legal Code" width="280" height="79" vspace="14" border="0" />
+</div>
+<p align="center"><b>Namensnennung&nbsp;– Weitergabe-unter-gleichen-Bedingungen 2.5
+Schweiz</b></p>
+<div class="text">
+<div class="fineprint" style="background:none;font-variant:small-caps;">
+Creative Commons Corporation ist keine Anwaltskanzlei und bietet keine rechtlichen
+Auskünfte bzw. Dienstleistungen an. Die Verbreitung dieser Lizenz führt nicht zu einem
+Mandatsverhältnis des Empfängers mit Creative Commons. Creative Commons übernimmt keine
+Gewähr für die zur Verfügung gestellten Informationen und lehnt jegliche Haftung für
+Schäden ab, die aus dem Gebrauch dieser Informationen erwachsen.
+Dieser Ausschluss von Gewährleistung und Haftung erstreckt sich auch auf die Personen, die
+an der Adaptierung des vorliegenden Lizenztexts ans schweizerische Recht mitgewirkt haben.
+</div>
+<p class="P4"><span class="T1">Lizenz<br />
+<br />
+Der</span> <span class="T2">„Lizenzgeber“</span><span class="T1">, d.h. die Person,
+welche den Lizenzgegenstand unter dieser Lizenz zur Verfügung stellt,<br />
+<br />
+und<br />
+<br /></span> <span class="T2">„Sie“</span><span class="T1">, d.h. die Person, welche aus
+dieser Lizenz Nutzungsrechte ableitet,<br />
+<br />
+vereinbaren mit dieser Creative Commons Public Licence ("CCPL" oder "Lizenz") die
+Nutzungsbedingungen für den Lizenzgegenstand,<br />
+<br />
+im Einzelnen:</span></p>
+<p class="P5">1.&nbsp;&nbsp;Definitionen</p>
+<p class="P6"><span class="T1">a.&nbsp;&nbsp;</span> <span class="T2">„Lizenzgegenstand“</span>
+<span class="T1">kann ein urheberrechtlich geschütztes Werk sein oder eine durch
+verwandte Schutzrechte geschützte Leistung;</span></p>
+<p class="P6"><span class="T1">b.&nbsp;&nbsp;&nbsp;ein</span> <span class="T2">„Sammelwerk“</span>
+<span class="T1">im Sinne dieser Lizenz ist eine Zusammenstellung des Lizenzgegenstands
+mit Werken oder sonstigen Elementen. Beim Sammelwerk sind Auswahl und Zusammenstellung
+als solche selbständig urheberrechtlich geschützt. Ein Sammelwerk gilt nicht als Werk
+zweiter Hand gemäss Ziff. 1 lit. c dieser Lizenz;</span></p>
+<p class="P6"><span class="T1">c.&nbsp;&nbsp;&nbsp;ein</span> <span class="T2">„Werk zweiter
+Hand“</span> <span class="T1">im Sinne dieser Lizenz ist eine geistige Schöpfung mit
+individuellem Charakter, die unter Verwendung des Lizenzgegenstands so geschaffen wird,
+dass der Lizenzgegenstand in seinem individuellen Charakter erkennbar bleibt;</span></p>
+<p class="P6"><span class="T1">d.&nbsp;&nbsp;</span> <span class="T2">„Urheber“</span>
+<span class="T1">ist, wer das Werk geschaffen hat;</span></p>
+<p class="P6"><span class="T1">e.&nbsp;&nbsp;&nbsp;ein</span> <span class="T2">„Werk“</span>
+<span class="T1">ist eine geistige Schöpfung mit individuellem Charakter;</span></p>
+<p class="P6"><span class="T1">f.&nbsp;&nbsp;&nbsp;&nbsp;ein</span> <span class="T2">„verwandtes
+Schutzrecht“</span> <span class="T1">ist ein Recht an einer kulturellen Leistung, welche
+nicht als Werk geschützt ist, wie etwa jene von ausübenden Künstlern, Herstellern von
+Ton- und Tonbildträgern oder Sendeunternehmen;</span></p>
+<p class="P6"><span class="T1">g.&nbsp;&nbsp;&nbsp;</span><span class="T2">„Lizenzelemente“</span> <span class="T1">sind die folgenden Lizenzcharakteristika: <br />
+„Namensnennung“, „Weitergabe-unter-gleichen-Bedingungen“, „Keine
+Bearbeitung“, „Nicht-kommerziell“. Sie werden vom Lizenzgeber ausgewählt und
+in der Bezeichnung dieser Lizenz
+soweit anwendbar genannt.</span></p>
+<p class="P7"><span class="T2">2.&nbsp;&nbsp;</span> <span class="T3">Schranken des
+Urheberrechts</span><span class="T2">.</span> <span class="T1">Dieser Lizenzvertrag lässt
+sämtliche Befugnisse unberührt, die sich aufgrund der Beschränkungen der
+ausschliesslichen Rechte des Rechtsinhabers durch das Urheberrechtsgesetz (Eigengebrauch,
+Erschöpfungsgrundsatz etc.) oder durch andere Bestimmungen der anwendbaren Gesetzgebung
+ergeben.</span></p>
+<p class="P7"><span class="T2">3.&nbsp;&nbsp;</span> <span class="T3">Lizenzierung</span><span class="T2">.</span> <span class="T1">Unter den Bestimmungen
+dieser Lizenz räumt Ihnen der Lizenzgeber die Befugnis ein, den Lizenzgegenstand
+weltweit, lizenzgebührenfrei, nicht exklusiv und zeitlich unbeschränkt (d.h. für die
+Schutzdauer des Werks oder des verwandten Schutzrechts) wie folgt zu nutzen:</span></p>
+<p class="P8">a.&nbsp;&nbsp;&nbsp;den Lizenzgegenstand zu vervielfältigen, ihn in ein oder mehrere
+Sammelwerke aufzunehmen und ihn im Rahmen des Sammelwerks zu vervielfältigen;</p>
+<p class="P8">b.&nbsp;&nbsp;&nbsp;den Lizenzgegenstand zu bearbeiten oder in anderer Weise
+umzugestalten;</p>
+<p class="P8">c.&nbsp;&nbsp;&nbsp;den Lizenzgegenstand oder Vervielfältigungen davon zu verbreiten,
+öffentlich wiederzugeben, durch Radio, Fernsehen oder ähnliche Einrichtungen, auch über
+Leitungen, zu senden, weiterzusenden oder sonstwie wahrnehmbar zu machen, wobei sich
+diese Befugnisse auch auf den in ein Sammelwerk aufgenommenen Lizenzgegenstand
+erstrecken;</p>
+<p class="P8">d.&nbsp;&nbsp;&nbsp;den bearbeiteten oder umgestalteten Lizenzgegenstand zu
+vervielfältigen, verbreiten, öffentlich wiederzugeben, durch Radio, Fernsehen oder
+ähnliche Einrichtungen, auch über Leitungen, zu senden, weiterzusenden oder sonstwie
+wahrnehmbar zu machen.</p>
+<p class="P99">Die vorstehend genannten Befugnisse können für alle Nutzungsarten sowie in
+jedem Medium und Format ausgeübt werden, ob diese bereits bekannt sind oder erst in
+Zukunft entwickelt werden. Diese Befugnisse umfassen auch das Recht zu Änderungen, die
+technisch notwendig sind, um die Befugnisse in anderen Medien und Formaten auszuüben.
+&nbsp;</p>
+<p class="P10">Diese Lizenz entbindet Sie nicht davon, allfällige nach dem anwendbaren
+Gesetz oder Nutzungstarif geschuldeten Vergütungen zu bezahlen. &nbsp;</p>
+<p class="P11"><span class="T2">4.&nbsp;&nbsp;</span> <span class="T3">Bedingungen</span><span class="T2">.</span> <span class="T1">Die in Ziff. 3
+eingeräumten Befugnisse unterliegen den folgenden Bedingungen:</span></p>
+<p class="P8">a.&nbsp;&nbsp;&nbsp;Die Ausübung eines Rechts aus dieser Lizenz muss von einer Kopie
+dieser Lizenz begleitet sein. Sie können davon absehen, wenn Sie anstatt dessen die
+jedermann zugängliche Fundstelle dieser Lizenz bekannt geben (Uniform Resource
+Identifier, URI). Sie müssen alle Hinweise auf diese Lizenz und auf ihre Klauseln
+betreffend Gewährleistungs- und Haftungsausschluss beibehalten. Sie dürfen keine
+Vereinbarungen treffen, welche die Bedingungen dieser Lizenz verändern oder die mit
+dieser Lizenz gewährten Rechte für einen Dritten einschränken. Sie dürfen für den
+Lizenzgegenstand keine Unterlizenz erteilen. Sie dürfen den Lizenzgegenstand nicht mit
+technischen Schutzmassnahmen versehen, die den Gebrauch des Lizenzgegenstands oder den
+Zugang zu diesem in einer Weise kontrollieren, die mit den Bedingungen dieser Lizenz im
+Widerspruch stehen.</p>
+<p class="P9">Das Vorstehende gilt auch, falls der Lizenzgegenstand Bestandteil eines
+Sammelwerks oder einer Datenbank ist. Dies bedeutet allerdings nicht, dass das Sammelwerk
+oder die Datenbank als solche diesen Lizenzbestimmungen unterstellt werden müssen.
+&nbsp;</p>
+<p class="P9">Wenn Sie den Lizenzgegenstand in ein Sammelwerk oder eine Datenbank
+aufnehmen, müssen Sie auf erste Anzeige des Urhebers oder jedes Lizenzgebers hin jeden
+Hinweis auf den Anzeigenden soweit machbar und gewünscht aus dem Sammelwerk bzw. der
+Datenbank entfernen; soweit Hinweise gestützt auf eine solche Anzeige zu entfernen sind,
+entfallen die Pflichten gemäss Ziff. 4 lit. c. Entsprechendes gilt bei Schöpfung eines
+Werks zweiter Hand.</p>
+<p class="P8">b.&nbsp;&nbsp;&nbsp;Sie dürfen ein Werk zweiter Hand ausschliesslich unter den
+Bedingungen dieser Lizenz, einer späteren Version dieser Lizenz mit denselben
+Lizenzelementen wie diese Lizenz oder einer Creative Commons iCommons Lizenz, die
+dieselben Lizenzelemente wie diese Lizenz enthält (z.B. Namensnennung –
+Weitergabe-unter-gleichen-Bedingungen 2.5 Schweden), vervielfältigen, verbreiten oder
+öffentlich wiedergeben.</p>
+<p class="P9">Sie müssen stets eine Kopie dieser Lizenz bzw. der von Ihnen gemäss dem
+vorhergehenden Satz ausgewählten Lizenz beifügen. Sie können davon absehen, wenn Sie
+anstatt dessen die jedermann zugängliche Fundstelle der massgeblichen Lizenz bekannt
+geben (Uniform Resource Identifier, URI). Sie müssen alle Hinweise auf diese Lizenz und
+auf ihre Klauseln betreffend Gewährleistungs- und Haftungsausschluss beibehalten. Sie
+dürfen keine Vereinbarungen treffen, welche die Bedingungen dieser Lizenz verändern oder
+die mit dieser Lizenz gewährten Rechte für einen Dritten einschränken. Sie dürfen das
+Werk zweiter Hand nicht mit technischen Schutzmassnahmen versehen, die den Gebrauch des
+Werks zweiter Hand oder den Zugang zu diesem in einer Weise kontrollieren, die mit den
+Bedingungen dieser Lizenz im Widerspruch stehen. &nbsp;</p>
+<p class="P9">Das Vorstehende gilt auch, falls das Werk zweiter Hand Bestandteil eines
+Sammelwerks oder einer Datenbank ist. Dies bedeutet allerdings nicht, dass das Sammelwerk
+oder die Datenbank als solche diesen Lizenzbestimmungen unterstellt werden müssen.</p>
+<p class="P8">c.&nbsp;&nbsp;&nbsp;Bei der Nutzung des Lizenzgegenstands oder eines Werks zweiter
+Hand, sei es isoliert oder als Teil eines Sammelwerks oder einer Datenbank, müssen Sie
+die bestehenden Copyright-Vermerke vollständig beibehalten bzw. in einem Rahmen
+wiedergeben, der dem technischen Verfahren und dem Trägermedium der von Ihnen
+vorgenommenen Nutzung angemessen ist. Insbesondere müssen Sie den Namen (oder das
+Pseudonym) des Urhebers sowie den Namen von Dritten nennen, die ein Lizenzgeber bzw. ein
+Urheber in den Copyright-Vermerk aufgenommen haben. Ist Ihnen der Titel des
+Lizenzgegenstands bekannt, müssen Sie diesen angeben. Hat der Lizenzgeber eine
+Internetadresse angegeben (z.B. in Form des Uniform Resource Identifier, URI), welche
+Lizenzinformationen oder Copyright-Vermerke enthält, müssen Sie diese ebenfalls nennen,
+soweit dies mit angemessenem Aufwand durchführbar ist.</p>
+<p class="P9">Bei Werken zweiter Hand müssen Sie einen Hinweis darauf anführen, in
+welcher Form der Lizenzgegenstand in die Bearbeitung eingegangen ist (z. B. „Französische
+Übersetzung des … (Werk) durch … (Urheber)“ oder „Das Drehbuch beruht auf dem Werk des …
+(Urheber)“). Diese Hinweise können in jeder angemessenen Weise erfolgen. Bei Werken
+zweiter Hand, Sammelwerken oder Datenbanken müssen solche Hinweise hinsichtlich
+Platzierung und Ausgestaltung mindestens ebenso auffällig und in vergleichbarer Weise
+ausgeführt werden, wie dies für die anderen Rechtsinhaber erfolgte. &nbsp;</p>
+<p class="P8">d.&nbsp;&nbsp;&nbsp;Obwohl die in Ziff. 3 eingeräumten Befugnisse nach Massgabe dieser
+Lizenz ausgeübt werden dürfen, findet diese Erlaubnis ihre gesetzliche Grenze in den
+Persönlichkeitsrechten der Urheber und ausübenden Künstler, deren berechtigte geistige
+und persönliche Interessen bzw. deren Ansehen oder Ruf durch die Nutzung nicht
+beeinträchtigt werden dürfen.</p>
+<p class="P12"><span class="T2">5.&nbsp;&nbsp;</span> <span class="T3">Keine Gewährleistung</span><span class="T2">.</span> <span class="T1">Sofern vom
+Lizenzgeber nicht schriftlich anders anerkannt, übernimmt der Lizenzgeber keine
+Gewährleistung für die erteilten Befugnisse.</span></p>
+<p class="P12"><span class="T2">6.&nbsp;&nbsp;</span> <span class="T3">Haftungsausschluss</span><span class="T2">.</span> <span class="T1">Über die in
+Ziff. 5 genannte Gewährleistung hinaus haftet der Lizenzgeber nur für Vorsatz und grobe
+Fahrlässigkeit. Jede andere Haftung ist ausgeschlossen, soweit gesetzlich zulässig. Für
+seine Hilfspersonen haftet der Lizenzgeber in keinem Fall. Dieser Haftungsausschluss gilt
+auch dann, wenn Sie auf die Möglichkeit einer Schädigung hingewiesen haben.</span></p>
+<p class="P5">7.&nbsp;&nbsp;&nbsp;Beendigung</p>
+<p class="P8">a.&nbsp;&nbsp;&nbsp;Diese Lizenz und die darunter eingeräumten Befugnisse fallen ohne
+weiteres und mit sofortiger Wirkung dahin, wenn Sie die Bedingungen dieser Lizenz
+verletzen. Die Ziffern 1, 2, 5, 6, 7 und 8 bleiben ungeachtet der Beendigung dieser
+Lizenz verbindlich.</p>
+<p class="P8">b.&nbsp;&nbsp;&nbsp;Die mit dieser Lizenz eingeräumten Befugnisse werden zeitlich
+uneingeschränkt eingeräumt (freilich höchstens für die Dauer, für welche der
+Lizenzgegenstand nach dem anwendbaren Recht urheber- bzw. leistungsschutzrechtlich
+geschützt ist). Der Lizenzgeber behält sich jedoch für einen beliebigen Zeitpunkt das
+Recht vor, den Lizenzgegenstand unter einer anderen Lizenz weiterzugeben oder die
+Verbreitung des Lizenzgegenstands ganz zu beenden. Der Lizenzwechsel wird jedoch nicht
+die Wirkung eines Widerrufs dieser Lizenz haben (oder jeder anderen Lizenzierung, die auf
+der Grundlage dieser Lizenz erfolgt oder erfolgen muss), vielmehr wird die Lizenz so
+lange weiter bestehen, als sie nicht nach lit. a vorstehend beendigt wurde.</p>
+<p class="P5">8.&nbsp;&nbsp;Verschiedenes</p>
+<p class="P8">a.&nbsp;&nbsp;&nbsp;Jedes Mal, wenn Sie den Lizenzgegenstand oder ein Sammelwerk
+gestützt auf Ziff. 3 dieser Lizenz nutzen, räumt der Lizenzgeber auch dem Empfänger eines
+allfälligen Vervielfältigungsstücks eine Lizenz am Lizenzgegenstand selber ein, und zwar
+zu denselben Bedingungen wie die Ihnen eingeräumte Lizenz.</p>
+<p class="P8">b.&nbsp;&nbsp;&nbsp;Jedes Mal, wenn Sie ein Werk zweiter Hand gestützt auf Ziff. 3
+dieser Lizenz nutzen, räumt der Lizenzgeber dem Empfänger eines Vervielfältigungsstücks
+eine Lizenz am Lizenzgegenstand selber ein, und zwar zu denselben Bedingungen wie die
+Ihnen eingeräumte Lizenz.</p>
+<p class="P8">c.&nbsp;&nbsp;&nbsp;Sollten sich einzelne Bestimmungen dieser Lizenz nach dem
+anwendbaren Recht als nicht durchsetzbar oder nichtig erweisen, so bleiben die übrigen
+Bestimmungen dieser Lizenz gültig und durchsetzbar und an die Stelle der unwirksamen
+Bestimmung tritt eine Ersatzregelung, die dem mit der unwirksamen Bestimmung angestrebten
+Zweck am nächsten kommt.</p>
+<p class="P8">d.&nbsp;&nbsp;&nbsp;Keine Bestimmung dieser Lizenz gilt als wegbedungen und keine
+Verletzung als genehmigt, bevor nicht die durch die Wegbedingung oder Genehmigung
+belastete Partei die Wegbedingung oder Genehmigung in Schriftform und unterschriftlich
+bestätigt hat.</p>
+<p class="P8">e.&nbsp;&nbsp;&nbsp;Diese Lizenz enthält alle mit Blick auf den Lizenzgegenstand
+zwischen den Parteien massgeblichen Bestimmungen. Andere Vertrauenspositionen, Abreden
+oder Zusicherungen im Hinblick auf den Lizenzgegenstand bestehen nicht. Der Lizenzgeber
+ist durch keine zusätzliche Klausel gebunden, welche sich aus irgendwelchen Unterlagen
+von Ihnen ergibt. Diese Vereinbarung kann ohne vorherige Vereinbarung mit
+unterschriftlicher Bestätigung zwischen dem Lizenzgeber und Ihnen nicht abgeändert
+werden.</p>
+<p class="P8" style="font-stretch:condensed;">f.&nbsp;&nbsp;&nbsp;&nbsp;Auf diesen Lizenzvertrag findet
+ausschliesslich schweizerisches Recht Anwendung.</p>
+<!-- BREAKOUT FOR CC NOTICE.  NOT A PART OF THE LICENSE -->
+<br />
+<div class="fineprint" style="font-variant:small-caps;">
+<p class="P13">Creative Commons ist nicht Partei dieses Lizenzvertrags und macht
+keinerlei Zusicherungen mit Blick auf den Lizenzgegenstand. Creative Commons haftet nicht
+für Ihnen entstandene Schäden aus der Verwendung des Lizenzgegenstands oder dieser
+Lizenz, aus welchem Rechtsgrund sie auch abgeleitet werden, sei es für direkten,
+indirekten Schaden oder für Folgeschaden. Ungeachtet des vorstehenden Satzes hat Creative
+Commons alle Rechte aus dieser Lizenz, sofern sie bezüglich eines Werks ausdrücklich
+selber als Lizenzgeberin unter dieser Lizenz auftritt.&nbsp;</p>
+<p class="P13">Ausser für den begrenzten Zweck, dem Publikum öffentlich bekannt zu
+machen, dass der Lizenzgegenstand unter der CCPL lizenziert ist, darf keine Partei dieser
+Lizenz das Markenzeichen "Creative Commons" oder irgend ein anderes Markenzeichen oder
+Logo von Creative Commons ohne die vorgängige schriftliche Zustimmung von Creative
+Commons verwenden. Jegliche erlaubte Nutzung hat in Übereinstimmung mit den dannzumal
+gültigen Markenrichtlinien von Creative Commons zu stehen. Die Markenrichtlinien von
+Creative Commons sind auf ihrer Website abrufbar oder erhältlich auf Anfrage.&nbsp;</p>
+<p class="P14">Creative Commons kann unter <a href="https://creativecommons.org" title="">https://creativecommons.org</a> kontaktiert
+werden.&nbsp;</p>
+</div><!-- END CC NOTICE -->
+</div>
+<div align="right" style="margin-bottom: 10px;padding-top:5px;">
+<a href="./" class="fulltext">« Back to Commons Deed</a>
+</div>
+</div>
+</body>
+</html>

--- a/benches/rawloader_c793a13/vendor/LICENSE.LGPL.txt
+++ b/benches/rawloader_c793a13/vendor/LICENSE.LGPL.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/registry.toml
+++ b/registry.toml
@@ -2352,6 +2352,11 @@ name = 'shrink_vec_u8_8_tuple'
 crate = 'quickcheck_0_6_1'
 entrypoint_path = 'benches/quickcheck_0_6_1/src/bin/shrink-vec-u8-8-tuple.rs'
 
+[benchmarks."rawloader_c793a13::benchmark"]
+name = 'benchmark::benchmark'
+crate = 'rawloader_c793a13'
+entrypoint_path = 'benches/rawloader_c793a13/src/bin/benchmark.rs'
+
 [benchmarks."rayon_1_0_0::factorial::factorial_iterator"]
 runner = 'molly'
 name = 'factorial::factorial_iterator'


### PR DESCRIPTION
Closes #46.

I am hoping for an early review, @anp. Some notes:

* This benchmark requires manually downloading an image file from the internet. It is Creative Commons Licensed, but cannot be downloaded by the benchmark itself due to Cloudflare. If you would prefer I commit the 18 MB file to the repo, I can.
* This library is LGPL 2.1, as is the benchmark code I started with. I have noted this in the license key of the Cargo.toml itself. If there is somewhere else I should note it, let me know.
* The benchmark code used to be an executable with a `main()` function that did its own iteration, and had no `black_box`. Therefore, I am hoping this version does not need a call to `black_box` either.
* It is not 100% clear to me whether the latest version of the library on crates.io matches master or not, so I pinned it by git commit, and use that as the version number.
* I am not touching anything about the runners, as per the directions.
* I am hoping the Cargo.lock additions will not break anything, and will pin its dependency version numbers. If I am wrong, how do I fix that?
* While I have verified the benchmark executes, I cannot figure out how to actually measure its performance on my own system to compare it with the original. `cargo bench` does nothing, and `cargo test --release` does not give me any numbers. Is this expected?

I imagine I left something out, so please let me know what. :smile: 